### PR TITLE
update versions, 10.9 is in brew, use suportedList, use REST-API

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,17 @@ function isSupported(mariadbVersion) {
   return supportedList.includes(mariadbVersion);
 }
 
+function fetchFullVersion(mariadbVersion) {
+  const json = execSync(`curl -Ls https://downloads.mariadb.org/rest-api/mariadb/${mariadbVersion}/latest/`, (error) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return mariadbVersion;
+    }
+  });
+  const result = Object.keys(JSON.parse(json).releases);
+  return result ? result : mariadbVersion;
+}
+
 const defaultVersion = supportedList[0];
 const mariadbVersion = parseFloat(process.env['INPUT_MARIADB-VERSION'] || defaultVersion).toFixed(1);
 
@@ -70,16 +81,8 @@ if (isMac()) {
   // install
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mariadb-'));
   process.chdir(tmpDir);
-  const versionMap = {
-    '10.9': '10.9.4',
-    '10.8': '10.8.6',
-    '10.7': '10.7.7',
-    '10.6': '10.6.11',
-    '10.5': '10.5.18',
-    '10.4': '10.4.27',
-    '10.3': '10.3.37'
-  };
-  const fullVersion = versionMap[mariadbVersion];
+  
+  const fullVersion = fetchFullVersion(mariadbVersion);
   run(`curl -Ls -o mariadb.msi https://downloads.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`);
   run(`msiexec /i mariadb.msi SERVICENAME=MariaDB /qn`);
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 const process = require('process');
 const spawnSync = require('child_process').spawnSync;
+const supportedList = ['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3'];
 
 function run(command) {
   console.log(command);
@@ -35,10 +36,14 @@ function isWindows() {
   return process.platform == 'win32';
 }
 
-const defaultVersion = isMac() ? '10.8' : '10.9';
+function isSupported(mariadbVersion) {
+  return supportedList.includes(mariadbVersion);
+}
+
+const defaultVersion = supportedList[0];
 const mariadbVersion = parseFloat(process.env['INPUT_MARIADB-VERSION'] || defaultVersion).toFixed(1);
 
-if (!['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3'].includes(mariadbVersion)) {
+if (!isSupported(mariadbVersion)) {
   throw 'Invalid MariaDB version: ' + mariadbVersion;
 }
 
@@ -66,13 +71,13 @@ if (isMac()) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mariadb-'));
   process.chdir(tmpDir);
   const versionMap = {
-    '10.9': '10.9.3',
-    '10.8': '10.8.5',
-    '10.7': '10.7.6',
-    '10.6': '10.6.10',
-    '10.5': '10.5.17',
-    '10.4': '10.4.26',
-    '10.3': '10.3.36'
+    '10.9': '10.9.4',
+    '10.8': '10.8.6',
+    '10.7': '10.7.7',
+    '10.6': '10.6.11',
+    '10.5': '10.5.18',
+    '10.4': '10.4.27',
+    '10.3': '10.3.37'
   };
   const fullVersion = versionMap[mariadbVersion];
   run(`curl -Ls -o mariadb.msi https://downloads.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`);


### PR DESCRIPTION
This PR:

* ~updates the windows versions~
* sets default macOS version to 10.9
* refactored some code for supported versions
* use REST API to fetch latest version for Windows