### PR TITLE
Fix #14 Add flow, Windows: add downloaddir option, make installer cacheable

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,52 @@
+---
+name: pre-commit
+on:
+  pull_request:
+  push:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      RAW_LOG: pre-commit.log
+      CS_XML: pre-commit.xml
+    steps:
+      - run: sudo apt-get update && sudo apt-get install cppcheck
+        if: false
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: false
+        with:
+          cache: pip
+          python-version: 3.12.1
+      - run: python -m pip install pre-commit
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit hooks
+        env:
+          SKIP: no-commit-to-branch
+        run: |
+          set -o pipefail
+          pre-commit gc
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee "${RAW_LOG}"
+      - name: Convert Raw Log to Checkstyle format (launch action)
+        uses: mdeweerd/logToCheckStyle@v2024.3.5
+        if: ${{ failure() }}
+        with:
+          in: ${{ env.RAW_LOG }}
+          # out: ${{ env.CS_XML }}
+      - uses: actions/cache/save@v4
+        if: ${{ ! cancelled() }}
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Provide log as artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ ! cancelled() }}
+        with:
+          name: precommit-logs
+          path: |
+            ${{ env.RAW_LOG }}
+            ${{ env.CS_XML }}
+          retention-days: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+---
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.3
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.11.1
+    hooks:
+      - id: eslint
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        stages: [commit]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.3
+    hooks:
+      - id: actionlint

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The missing action for MariaDB :tada:
 Add it as a step to your workflow
 
 ```yml
-      - uses: ankane/setup-mariadb@v1
+- uses: ankane/setup-mariadb@v1
 ```
 
 ## Versions
@@ -21,34 +21,34 @@ Add it as a step to your workflow
 Specify a version
 
 ```yml
-      - uses: ankane/setup-mariadb@v1
-        with:
-          mariadb-version: "11.4"
+- uses: ankane/setup-mariadb@v1
+  with:
+    mariadb-version: "11.4"
 ```
 
 Currently supports
 
-Version | `11.4` | `10.11` | `10.6` | `10.5`
---- | --- | --- | --- | ---
-`ubuntu-24.04` | default | ✓ | |
-`ubuntu-22.04` | default | ✓ | ✓ |
-`ubuntu-20.04` | default | ✓ | ✓ | ✓
-`macos-14` | default | ✓ | ✓ | ✓
-`macos-13` | default | ✓ | ✓ | ✓
-`macos-12` | default | ✓ | ✓ | ✓
-`windows-2022` | default | ✓ | ✓ | ✓
-`windows-2019` | default | ✓ | ✓ | ✓
+| Version        | `11.4`  | `10.11` | `10.6` | `10.5` |
+| -------------- | ------- | ------- | ------ | ------ |
+| `ubuntu-24.04` | default | ✓       |        |        |
+| `ubuntu-22.04` | default | ✓       | ✓      |        |
+| `ubuntu-20.04` | default | ✓       | ✓      | ✓      |
+| `macos-14`     | default | ✓       | ✓      | ✓      |
+| `macos-13`     | default | ✓       | ✓      | ✓      |
+| `macos-12`     | default | ✓       | ✓      | ✓      |
+| `windows-2022` | default | ✓       | ✓      | ✓      |
+| `windows-2019` | default | ✓       | ✓      | ✓      |
 
 Test against multiple versions
 
 ```yml
-    strategy:
-      matrix:
-        mariadb-version: ["11.4", "10.11", "10.6"]
-    steps:
-      - uses: ankane/setup-mariadb@v1
-        with:
-          mariadb-version: ${{ matrix.mariadb-version }}
+strategy:
+  matrix:
+    mariadb-version: ["11.4", "10.11", "10.6"]
+steps:
+  - uses: ankane/setup-mariadb@v1
+    with:
+      mariadb-version: ${{ matrix.mariadb-version }}
 ```
 
 ## Options
@@ -56,9 +56,9 @@ Test against multiple versions
 Create a database
 
 ```yml
-      - uses: ankane/setup-mariadb@v1
-        with:
-          database: testdb
+- uses: ankane/setup-mariadb@v1
+  with:
+    database: testdb
 ```
 
 ## Extra Steps
@@ -66,7 +66,7 @@ Create a database
 Run queries
 
 ```yml
-      - run: mysql -D testdb -e 'SELECT VERSION()'
+- run: mysql -D testdb -e 'SELECT VERSION()'
 ```
 
 ## Related Actions

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,14 @@
 name: Setup MariaDB
+description: Setup MariaDB in github workflow
 inputs:
   mariadb-version:
     description: The MariaDB version to download (if necessary) and use
   database:
     description: Database to create
+  downloaddir:
+    description: Directory to cache MariaDB data
+    required: false
+    default: ".cache/mariadb"
 runs:
   using: node20
   main: index.js

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ if (isMac()) {
     '10.5': '10.5.23'
   };
   const fullVersion = versionMap[mariadbVersion];
-  run(`curl -Ls -o mariadb.msi https://downloads.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`);
+  run(`curl -Ls -o mariadb.msi https://dlm.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`);
   run(`msiexec /i mariadb.msi SERVICENAME=MariaDB /qn`);
 
   bin = `C:\\Program Files\\MariaDB ${mariadbVersion}\\bin`;

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ if (isMac()) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mariadb-'));
   process.chdir(tmpDir);
   const versionMap = {
-    '11.4': '11.4.2',
+    '11.4': '11.4.3',
     '11.2': '11.2.2',
     '11.1': '11.1.2',
     '11.0': '11.0.4',

--- a/index.js
+++ b/index.js
@@ -1,24 +1,24 @@
 const execSync = require("child_process").execSync;
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const process = require('process');
-const spawnSync = require('child_process').spawnSync;
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const process = require("process");
+const spawnSync = require("child_process").spawnSync;
 
 function run(command) {
   console.log(command);
   let env = Object.assign({}, process.env);
   delete env.CI; // for Homebrew
-  env.HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK = '1';
-  execSync(command, {stdio: 'inherit', env: env});
+  env.HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK = "1";
+  execSync(command, { stdio: "inherit", env: env });
 }
 
 function runSafe() {
   const args = Array.from(arguments);
-  console.log(args.join(' '));
+  console.log(args.join(" "));
   const command = args.shift();
   // spawn is safer and more lightweight than exec
-  const ret = spawnSync(command, args, {stdio: 'inherit'});
+  const ret = spawnSync(command, args, { stdio: "inherit" });
   if (ret.status !== 0) {
     throw ret.error;
   }
@@ -29,83 +29,118 @@ function addToPath(newPath) {
 }
 
 function isMac() {
-  return process.platform == 'darwin';
+  return process.platform == "darwin";
 }
 
 function isWindows() {
-  return process.platform == 'win32';
+  return process.platform == "win32";
 }
 
 function formulaPresent(formula) {
-  const tapPrefix = process.arch == 'arm64' ? '/opt/homebrew' : '/usr/local/Homebrew';
+  const tapPrefix =
+    process.arch == "arm64" ? "/opt/homebrew" : "/usr/local/Homebrew";
   const tap = `${tapPrefix}/Library/Taps/homebrew/homebrew-core`;
-  return fs.existsSync(`${tap}/Formula/${formula[0]}/${formula}.rb`) || fs.existsSync(`${tap}/Aliases/${formula}`);
+  return (
+    fs.existsSync(`${tap}/Formula/${formula[0]}/${formula}.rb`) ||
+    fs.existsSync(`${tap}/Aliases/${formula}`)
+  );
 }
 
 // latest LTS release
-const defaultVersion = '11.4';
-const mariadbVersion = process.env['INPUT_MARIADB-VERSION'] || defaultVersion;
+const defaultVersion = "11.4";
+const mariadbVersion = process.env["INPUT_MARIADB-VERSION"] || defaultVersion;
 
 // only add LTS releases going forward
-if (!['11.4', '11.2', '11.1', '10.11', '10.6', '10.5'].includes(mariadbVersion)) {
-  throw 'Invalid MariaDB version: ' + mariadbVersion;
+if (
+  !["11.4", "11.2", "11.1", "10.11", "10.6", "10.5"].includes(mariadbVersion)
+) {
+  throw "Invalid MariaDB version: " + mariadbVersion;
 }
 
-const database = process.env['INPUT_DATABASE'];
+const database = process.env["INPUT_DATABASE"];
+
+const input_downloaddir = process.env["INPUT_DOWNLOADDIR"];
+
+// Convert downloaddir to a System Path (e.g., '/' to '\\' on windows
+const downloadDirPath = path.parse(input_downloaddir);
+const dirParts = downloadDirPath.dir.split(/[\\/]/);
+downloadDirPath.dir = dirParts.length > 0 ? path.join(...dirParts) : ".";
+const downloaddir = path.format(downloadDirPath);
 
 let bin;
 
 if (isMac()) {
   const formula = `mariadb@${mariadbVersion}`;
   if (!formulaPresent(formula)) {
-    run('brew update');
+    run("brew update");
   }
 
   // install
   run(`brew install ${formula}`);
 
   // start
-  const prefix = process.arch == 'arm64' ? '/opt/homebrew' : '/usr/local';
+  const prefix = process.arch == "arm64" ? "/opt/homebrew" : "/usr/local";
   bin = `${prefix}/opt/${formula}/bin`;
   run(`${bin}/mysql.server start`);
 
   addToPath(bin);
 } else if (isWindows()) {
   // install
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mariadb-'));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mariadb-"));
   process.chdir(tmpDir);
   const versionMap = {
-    '11.4': '11.4.2',
-    '11.2': '11.2.2',
-    '11.1': '11.1.2',
-    '11.0': '11.0.4',
-    '10.11': '10.11.6',
-    '10.6': '10.6.16',
-    '10.5': '10.5.23'
+    11.4: "11.4.2",
+    11.2: "11.2.2",
+    11.1: "11.1.2",
+    "11.0": "11.0.4",
+    10.11: "10.11.6",
+    10.6: "10.6.16",
+    10.5: "10.5.23",
   };
   const fullVersion = versionMap[mariadbVersion];
-  run(`curl -Ls -o mariadb.msi https://downloads.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`);
-  run(`msiexec /i mariadb.msi SERVICENAME=MariaDB /qn`);
+  const targetPath = path.join(downloaddir, `mariadb-${fullVersion}.msi`);
+
+  // Ensure that '$downloaddir' exists
+  if (!fs.existsSync(downloaddir)) {
+    fs.mkdirSync(downloaddir, { recursive: true });
+  }
+  bin = `${downloaddir}\\mariadb-${fullVersion}.msi`;
+  if (!fs.existsSync(targetPath)) {
+    run(
+      `curl -Ls -o "${targetPath}" https://downloads.mariadb.com/MariaDB/mariadb-${fullVersion}/winx64-packages/mariadb-${fullVersion}-winx64.msi`,
+    );
+  }
+  run(`"${targetPath}" /i mariadb.msi SERVICENAME=MariaDB /qn`);
 
   bin = `C:\\Program Files\\MariaDB ${mariadbVersion}\\bin`;
   addToPath(bin);
 
   // add user
-  run(`"${bin}\\mysql" -u root -e "CREATE USER 'runneradmin'@'localhost' IDENTIFIED BY ''"`);
-  run(`"${bin}\\mysql" -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'runneradmin'@'localhost'"`);
+  run(
+    `"${bin}\\mysql" -u root -e "CREATE USER 'runneradmin'@'localhost' IDENTIFIED BY ''"`,
+  );
+  run(
+    `"${bin}\\mysql" -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'runneradmin'@'localhost'"`,
+  );
   run(`"${bin}\\mysql" -u root -e "FLUSH PRIVILEGES"`);
 } else {
-  const image = process.env['ImageOS'];
-  if (image == 'ubuntu20' || image == 'ubuntu22' || image == 'ubuntu24') {
+  const image = process.env["ImageOS"];
+  if (image == "ubuntu20" || image == "ubuntu22" || image == "ubuntu24") {
     // clear previous data
     run(`sudo systemctl stop mysql.service`);
     run(`sudo rm -rf /var/lib/mysql`);
   }
 
   // install
-  run(`sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8`);
-  run(`echo "deb [arch=amd64,arm64] https://dlm.mariadb.com/repo/mariadb-server/${mariadbVersion}/repo/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) main" | sudo tee /etc/apt/sources.list.d/mariadb.list`);
-  run(`sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"`);
+  run(
+    `sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8`,
+  );
+  run(
+    `echo "deb [arch=amd64,arm64] https://dlm.mariadb.com/repo/mariadb-server/${mariadbVersion}/repo/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) main" | sudo tee /etc/apt/sources.list.d/mariadb.list`,
+  );
+  run(
+    `sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"`,
+  );
   run(`sudo apt-get install mariadb-server`);
 
   // start
@@ -119,10 +154,9 @@ if (isMac()) {
   run(`sudo mysql -e "GRANT ALL PRIVILEGES ON *.* TO '$USER'@'localhost'"`);
   run(`sudo mysql -e "FLUSH PRIVILEGES"`);
 
-
   bin = `/usr/bin`;
 }
 
 if (database) {
-  runSafe(path.join(bin, 'mysqladmin'), 'create', database);
+  runSafe(path.join(bin, "mysqladmin"), "create", database);
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "setup-mariadb-action",
+  "version": "v1.0",
+  "description": "Setup mariadb-action"
+}


### PR DESCRIPTION
# Fix #14 

On Windows, this PR downloads the setup file to a .cache/mariadb directory by default.
The file is downloaded only if the target does not exist.
The directory is configurable.
The downloaded filename now also contains the version.

By doing so it is possible to setup a cache action that caches the setup executables.
By putting the file in the .cache directory, it may be located in the directory that is already cached in the end action.